### PR TITLE
fix cloneWithProps on rowRenderer

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -82,7 +82,7 @@ var Canvas = React.createClass({
 
   renderRow: function(props) {
     if (React.isValidComponent(this.props.rowRenderer)) {
-      return cloneWithProps(this.props.rowRenderer, props);
+      return cloneWithProps(this.props.rowRenderer(props), props);
     } else {
       return this.props.rowRenderer(props);
     }


### PR DESCRIPTION
it was passing a func, not an obj, which caused React to throw
