### PR TITLE
Fixes issue where rendered rows refs start and end keys can get out of r...

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -179,8 +179,9 @@ var Canvas = React.createClass({
 
   setScrollLeft(scrollLeft) {
     if (this._currentRowsLength !== undefined) {
-      for (var i = 0, len = this._currentRowsLength; i < len; i++) {
-        this.refs[i].setScrollLeft(scrollLeft);
+        Object.keys(this.refs).forEach(function(key){
+            this.refs[key].setScrollLeft(scrollLeft)
+        }, this);
       }
     }
   },

--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -182,7 +182,6 @@ var Canvas = React.createClass({
         Object.keys(this.refs).forEach(function(key){
             this.refs[key].setScrollLeft(scrollLeft)
         }, this);
-      }
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "reactify": "^0.14.0"
   },
   "peerDependencies": {
-    "react": "^0.11.1"
+    "react": ">=0.11.1"
   },
   "devDependencies": {
     "browserify": "^5.9.1",


### PR DESCRIPTION
...ange

In some cases where viewport size for canvas is dynamic the ref index for rendered rows does not match the assumed values for the setScrollLeft method. Iterating over the object keys to obtain a handle on the refs independent of the current row length fixes this issue.
